### PR TITLE
Switch to distroless image and don't run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
-RUN apk add --no-cache ca-certificates
+FROM gcr.io/distroless/static-debian11:nonroot
 COPY alertmanager-bot /
+USER nonroot
 ENTRYPOINT ["/alertmanager-bot"]


### PR DESCRIPTION
- distroless is smaller images and more secure than alpine, it's a perfect fit for static go apps
- with nonroot tag of distroless images we get a nonroot user ready to be used with the container, so use this user so we don't run as root when not needed

ref: https://github.com/GoogleContainerTools/distroless